### PR TITLE
ci: enable checked unattended Renovate updates

### DIFF
--- a/.github/merge-policy.json
+++ b/.github/merge-policy.json
@@ -1,0 +1,21 @@
+{
+	"schema": 1,
+	"enabled": true,
+	"ci_workflow": "ci.yml",
+	"required_checks": [
+		"guard",
+		"quality / verify",
+		"test-build / verify",
+		"hygiene / verify",
+		"ci / required"
+	],
+	"optional_checks": [],
+	"check_app_id": 15368,
+	"renovate": {
+		"login": "renovate[bot]",
+		"id": 29139614
+	},
+	"renovate_comment": "/merge-when-green",
+	"minimum_approvals": 0,
+	"deploy_workflows": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ name: ci
         description: Exact repaired PR commit
         type: string
         default: ''
+      expected-default-sha:
+        description: Exact default-branch commit requested after a checked merge
+        type: string
+        default: ''
 permissions:
   contents: read
   pull-requests: read
@@ -30,6 +34,7 @@ jobs:
         token: ${{ github.token }}
         pr-number: ${{ inputs.pr-number }}
         expected-head-sha: ${{ inputs.expected-head-sha }}
+        expected-default-sha: ${{ inputs.expected-default-sha }}
   quality:
     needs: guard
     uses: edbfi/automation/.github/workflows/bun.yml@v1.0.0
@@ -67,6 +72,7 @@ jobs:
         token: ${{ github.token }}
         pr-number: ${{ inputs.pr-number }}
         expected-head-sha: ${{ inputs.expected-head-sha }}
+        expected-default-sha: ${{ inputs.expected-default-sha }}
     - uses: edbfi/automation/actions/gate@v1.0.0
       with:
         needs: ${{ toJSON(needs) }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,28 @@
+name: Checked merge
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [synchronize, reopened, edited, ready_for_review]
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+permissions: {}
+concurrency:
+  group: checked-merge
+  cancel-in-progress: false
+jobs:
+  merge:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: write
+      checks: read
+    steps:
+      - uses: edbfi/automation/actions/merge@v1.1.0
+        with:
+          token: ${{ github.token }}

--- a/CI.md
+++ b/CI.md
@@ -16,9 +16,11 @@ also propagates SvelteKit preparation failures instead of masking them.
 Shared workflows and actions use immutable full version tags in `edbfi/automation`.
 Renovate's shared preset preserves grouped non-major updates, handles Biome package
 and schema versions through the official manager, and updates actions, hooks and Bun.
-TypeScript is capped below 7 until Svelte's compiler API support is verified.
-Automerge stays disabled during adoption until the corrected shared policy and
-required checks are configured and validated.
+The v1.1.0 default and automerge presets make all update types eligible, including
+majors and shared-policy updates, without dashboard approval. All five current-head
+checks in `.github/merge-policy.json` must pass; Svelte checks remain required to
+test TypeScript compatibility. The checked merge preserves genuine sign-offs and
+dispatches full CI for the exact merged commit.
 
 The previous CI could rewrite and push code, ignore formatting errors, and skip
 fresh workflow execution after a token-authenticated push. Biome repair now computes
@@ -26,9 +28,11 @@ in isolation with read-only permissions, then publishes only allowlisted changes
 explicitly dispatches full CI for the exact repaired SHA. It cannot edit workflows,
 package manifests or lockfiles. Broad repairs beyond the shared size limits are manual.
 
-Require `ci / required` with up-to-date branches, include administrators, and disable
-force pushes/deletion. CI has read-only permissions, timeouts, lockfile/runtime caches
-and cancellation for superseded runs; only the separate repair publisher can write.
+Other changes retain manual review of the exact head/base, full diff, authors/DCO,
+all expected CI and relevant artifacts before merging through ghmerge. No branch
+protections or repository rulesets are configured. CI has read-only permissions,
+timeouts, lockfile/runtime caches and cancellation for superseded runs; repair and
+checked merging use separate privileged jobs.
 The large offline suite covers server behavior but does not replace real Plex
 integration or visual browser checks. Installed Playwright tooling alone is not
 claimed as browser coverage; no browser test suite is configured in this repository.

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>edbfi/automation:default#v1.0.0"],
-	"gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
-	"packageRules": [
-		{
-			"description": "Review TypeScript 7 when Svelte language tools support its API.",
-			"matchPackageNames": ["typescript"],
-			"allowedVersions": "<7"
-		}
-	]
+	"extends": [
+		"github>edbfi/automation//default.json#v1.1.0",
+		"github>edbfi/automation//automerge.json#v1.1.0"
+	],
+	"gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]
 }


### PR DESCRIPTION
Renovate updates become eligible for unattended checked merging after all five current-head CI checks pass, including majors and shared-policy updates. Remove the TypeScript cap, preserve genuine sign-offs and dispatch full CI for the exact merged commit. Existing Biome repair scopes, application code, pins and prek remain unchanged; the separate Docker repository is excluded.

Local strict schema/actionlint/prek, Biome, Svelte, 2,476 Bun tests, existing 80% line/function coverage gates, production build and disposable-database real-server smoke passed. Existing absence of real-browser E2E and live Plex integration remains documented. No branch protections or repository rulesets.
